### PR TITLE
Autohook using normal hook while Patience is up

### DIFF
--- a/AutoHook/Ui/TabBaseConfig.cs
+++ b/AutoHook/Ui/TabBaseConfig.cs
@@ -55,6 +55,12 @@ abstract class TabBaseConfig : IDisposable
         if (enabled)
         {
             ImGui.Indent();
+            if (ImGui.RadioButton($"Hook###{TabName}{hook}0", type == HookType.Normal))
+            {
+                type = HookType.Normal;
+                Service.Configuration.Save();
+            }
+
             if (ImGui.RadioButton($"Precision Hookset###{TabName}{hook}1", type == HookType.Precision))
             {
                 type = HookType.Precision;


### PR DESCRIPTION
This allows using normal hook to "cancel" the current cast without wasting GP on a bite that would yield an undesirable fish