### PR TITLE
Added option for stop after X AA stacks

### DIFF
--- a/AutoHook/Configurations/BaitConfig.cs
+++ b/AutoHook/Configurations/BaitConfig.cs
@@ -56,6 +56,9 @@ public class BaitConfig
     public bool StopAfterCaught = false;
     public int StopAfterCaughtLimit = 1;
 
+    public bool StopAfterAnglersArt = false;
+    public int StopAfterAnglersArtLimit = 1;
+
     public BaitConfig(string bait)
     {
         BaitName = bait;

--- a/AutoHook/HookManager.cs
+++ b/AutoHook/HookManager.cs
@@ -198,6 +198,15 @@ public class HookingManager : IDisposable
             state = FishingState.Quit;
         }
 
+        if (_selectedPreset != null && _selectedPreset.StopAfterAnglersArt)
+        {
+            bool hasStacks = PlayerResources.HasAnglersArtStacks(_selectedPreset.StopAfterAnglersArtLimit);
+
+        if (hasStacks)
+            {
+                state = FishingState.Quit;
+            }
+        }
         //CheckState();
 
         // FishBit in this case means that the fish was hooked, but it escaped. I might need to find a way to check if the fish was caught or not.

--- a/AutoHook/Resources/Localization/UIStrings.Designer.cs
+++ b/AutoHook/Resources/Localization/UIStrings.Designer.cs
@@ -133,6 +133,25 @@ namespace AutoHook.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to After X stacks of Anglers Art....
+        /// </summary>
+        internal static string AfterAnglersArt {
+            get {
+                return ResourceManager.GetString("AfterAnglersArt", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to - If this config is a bait: Stops fishing after X stacks of Anglers Art
+        ///- If this config is a fish: Stops fishing after X stacks of Anglers Art.
+        /// </summary>
+        internal static string AfterAnglersArtDescription {
+            get {
+                return ResourceManager.GetString("AfterAnglersArtDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A preset with the same name already exists.
         /// </summary>
         internal static string APresetWithTheSameNameAlreadyExists {

--- a/AutoHook/Resources/Localization/UIStrings.resx
+++ b/AutoHook/Resources/Localization/UIStrings.resx
@@ -317,6 +317,13 @@ Set Zero (0) to disable</value>
     <value>- If this config is a bait: Stops fishing after X amount of fish is caught
 - If this config is a fish: Stops fishing after it being caught X amount of times</value>
   </data>
+  <data name="AfterAnglersArt" xml:space="preserve">
+    <value>After X stacks of Anglers Art...</value>
+  </data>
+  <data name="AfterAnglersArtDescription" xml:space="preserve">
+    <value>- If this config is a bait: Stops fishing after X stacks of Anglers Art
+- If this config is a fish: Has no effect, only works on baits!</value>
+  </data>
   <data name="TimeS" xml:space="preserve">
     <value>Time(s)</value>
     <comment>Quantity, example: 5 Time(s) </comment>

--- a/AutoHook/Ui/TabBaseConfig.cs
+++ b/AutoHook/Ui/TabBaseConfig.cs
@@ -362,7 +362,6 @@ internal abstract class TabBaseConfig : IDisposable
             if (DrawUtil.Checkbox(UIStrings.AfterBeingCaught, ref cfg.StopAfterCaught,
                 UIStrings.AfterBeingCaughtDescription))
             {
-                //cfg.StopAfterCaught = true;
                 cfg.StopAfterAnglersArt = false;
                 Service.Configuration.Save();
             }
@@ -370,7 +369,6 @@ internal abstract class TabBaseConfig : IDisposable
             if (DrawUtil.Checkbox(UIStrings.AfterAnglersArt, ref cfg.StopAfterAnglersArt,
                 UIStrings.AfterAnglersArtDescription))
             {
-                //cfg.StopAfterAnglersArt = true;
                 cfg.StopAfterCaught = false;
                 Service.Configuration.Save();
             }

--- a/AutoHook/Ui/TabBaseConfig.cs
+++ b/AutoHook/Ui/TabBaseConfig.cs
@@ -360,8 +360,19 @@ internal abstract class TabBaseConfig : IDisposable
             ImGui.TextColored(ImGuiColors.DalamudYellow, UIStrings.StopFishing);
             ImGui.Spacing();
             if (DrawUtil.Checkbox(UIStrings.AfterBeingCaught, ref cfg.StopAfterCaught,
-                    UIStrings.AfterBeingCaughtDescription))
+                UIStrings.AfterBeingCaughtDescription))
             {
+                //cfg.StopAfterCaught = true;
+                cfg.StopAfterAnglersArt = false;
+                Service.Configuration.Save();
+            }
+
+            if (DrawUtil.Checkbox(UIStrings.AfterAnglersArt, ref cfg.StopAfterAnglersArt,
+                UIStrings.AfterAnglersArtDescription))
+            {
+                //cfg.StopAfterAnglersArt = true;
+                cfg.StopAfterCaught = false;
+                Service.Configuration.Save();
             }
 
             if (cfg.StopAfterCaught)
@@ -372,6 +383,22 @@ internal abstract class TabBaseConfig : IDisposable
                 {
                     if (cfg.StopAfterCaughtLimit < 1)
                         cfg.StopAfterCaughtLimit = 1;
+                }
+
+                ImGui.Unindent();
+            }
+
+            if (cfg.StopAfterAnglersArt)
+            {
+                ImGui.Indent();
+                ImGui.SetNextItemWidth(90 * ImGuiHelpers.GlobalScale);
+                if (ImGui.InputInt(UIStrings.TabAutoCasts_DrawExtraOptionsThaliaksFavor_, ref cfg.StopAfterAnglersArtLimit))
+                {
+                    if (cfg.StopAfterAnglersArtLimit < 1)
+                        cfg.StopAfterAnglersArtLimit = 1;
+
+                    if (cfg.StopAfterAnglersArtLimit >= 10)
+                        cfg.StopAfterAnglersArtLimit = 10;
                 }
 
                 ImGui.Unindent();


### PR DESCRIPTION
First time doing much in C#, tried to follow the existing code as much as I could.

Added a check to stop after a certain amount of AA stacks was reached, handy for things like Ruby Dragon prep where stacks for makeshift bait are required or if you want manual control over things like Makeshift Bait or Thaliak's Favor use. I had to move the AA stack check into `OnFrameworkUpdate` so that the check is done before cast. I'm not sure this is the right place for it, but when it was in `OnCatch` sometimes the check would happen before the AA stack hit so we wouldn't stop until the next catch. I've marked this as a bait only check, though depending on how mooches are processed it may still work on fish as well.