### PR TITLE
Fix swapping both bait and preset together when fish caught

### DIFF
--- a/AutoHook/HookManager.cs
+++ b/AutoHook/HookManager.cs
@@ -259,7 +259,7 @@ public class HookingManager : IDisposable
             {
                 var result = Service.EquipedBait.ChangeBait(lastFishCatchCfg.BaitToSwap);
 
-                _lastStep |= FishingSteps.BaitSwapped; // one try per catch
+                _lastStep = FishingSteps.BaitSwapped; // one try per catch
 
                 if (result == CurrentBait.ChangeBaitReturn.Success)
                 {
@@ -276,7 +276,7 @@ public class HookingManager : IDisposable
             {
                 var preset =
                     Presets.CustomPresets.FirstOrDefault(preset => preset.PresetName == lastFishCatchCfg.PresetToSwap);
-                _lastStep |= FishingSteps.PresetSwapped; // one try per catch
+                _lastStep = FishingSteps.PresetSwapped; // one try per catch
 
                 if (preset != null)
                 {


### PR DESCRIPTION
When a fish catch config is set to simultaneously swap bait and swap preset, only bait is swapped and preset remains unchanged instead of both being swapped. This was due to FishingSteps being treated as a bitmask rather than a normal enum.